### PR TITLE
feat: add support for address field

### DIFF
--- a/internal/asyncapi/channel.go
+++ b/internal/asyncapi/channel.go
@@ -21,6 +21,7 @@ type Channel struct {
 
 	XGoName string `json:"x-go-name" yaml:"x-go-name"`
 	XIgnore bool   `json:"x-ignore" yaml:"x-ignore"`
+	Address string `json:"address" yaml:"address"`
 
 	Ref string `json:"$ref" yaml:"$ref"`
 }
@@ -57,6 +58,7 @@ func (c Channel) build(ctx *common.CompileContext, channelKey string) (common.Re
 	// Render only the channels defined directly in `channels` document section, not in `components`
 	res := &render.Channel{
 		Name:                chName,
+		Address:             c.Address,
 		GolangName:          ctx.GenerateObjName(chName, ""),
 		RawName:             channelKey,
 		AllProtoChannels:    make(map[string]common.Renderer),

--- a/internal/render/channel.go
+++ b/internal/render/channel.go
@@ -11,6 +11,7 @@ import (
 
 type Channel struct {
 	Name                string // Channel name, typically equals to Channel key, can get overridden in x-go-name
+	Address             string // Channel address
 	GolangName          string // Name of channel struct
 	DirectRender        bool   // Typically, it's true if channel is defined in `channels` section, false if in `components` section
 	Dummy               bool
@@ -109,6 +110,11 @@ func (c Channel) String() string {
 func (c Channel) renderChannelNameFunc(ctx *common.RenderContext) []*j.Statement {
 	ctx.Logger.Trace("renderChannelNameFunc")
 
+	address := c.Address
+	if address == "" {
+		address = c.RawName
+	}
+
 	// Channel1Name(params Chan1Parameters) runtime.ParamString
 	return []*j.Statement{
 		j.Func().Id(c.GolangName+"Name").
@@ -121,7 +127,7 @@ func (c Channel) renderChannelNameFunc(ctx *common.RenderContext) []*j.Statement
 			BlockFunc(func(bg *j.Group) {
 				if c.ParametersStruct == nil {
 					bg.Return(j.Qual(ctx.RuntimeModule(""), "ParamString").Values(j.Dict{
-						j.Id("Expr"): j.Lit(c.RawName),
+						j.Id("Expr"): j.Lit(address),
 					}))
 				} else {
 					bg.Op("paramMap := map[string]string").Values(j.DictFunc(func(d j.Dict) {
@@ -130,7 +136,7 @@ func (c Channel) renderChannelNameFunc(ctx *common.RenderContext) []*j.Statement
 						}
 					}))
 					bg.Return(j.Qual(ctx.RuntimeModule(""), "ParamString").Values(j.Dict{
-						j.Id("Expr"):       j.Lit(c.RawName),
+						j.Id("Expr"):       j.Lit(address),
 						j.Id("Parameters"): j.Id("paramMap"),
 					}))
 				}


### PR DESCRIPTION
Referencing channels does not seem to work well with parameterized channel names (even with URL substitution). I was too lazy to check what the exact problem is, but the AsyncAPI spec also defines an address field to allow using more simple channel names while still supporting parameters.